### PR TITLE
Add Go 1.24+ native H2C support examples

### DIFF
--- a/cmd-1_24/client/main.go
+++ b/cmd-1_24/client/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+)
+
+func main() {
+	// Get URL from command line or use default
+	url := "http://localhost:8080/test"
+	if len(os.Args) > 1 {
+		url = os.Args[1]
+	}
+
+	// Configure protocols for H2C-only support (HTTP/2 cleartext)
+	protocols := new(http.Protocols)
+	protocols.SetUnencryptedHTTP2(true) // Enable H2C (HTTP/2 cleartext)
+	protocols.SetHTTP1(false)           // Explicitly disable HTTP/1.1
+	protocols.SetHTTP2(false)           // Explicitly disable encrypted HTTP/2 (HTTPS)
+
+	// Create client with H2C transport configuration
+	client := &http.Client{
+		Transport: &http.Transport{
+			Protocols: protocols,
+		},
+	}
+
+	// Make the request
+	log.Printf("Requesting: %s", url)
+	resp, err := client.Get(url)
+	if err != nil {
+		log.Fatalf("Request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Read response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatalf("Failed to read response: %v", err)
+	}
+
+	// Display response information
+	fmt.Printf("Response Status: %s\n", resp.Status)
+	fmt.Printf("Protocol: HTTP/%d.%d\n", resp.ProtoMajor, resp.ProtoMinor)
+	fmt.Printf("Headers:\n")
+	for key, values := range resp.Header {
+		for _, value := range values {
+			fmt.Printf("  %s: %s\n", key, value)
+		}
+	}
+	fmt.Printf("\nBody:\n%s", body)
+}

--- a/cmd-1_24/server/main.go
+++ b/cmd-1_24/server/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+)
+
+func main() {
+	// Configure protocols for H2C-only support (HTTP/2 cleartext)
+	protocols := new(http.Protocols)
+	protocols.SetUnencryptedHTTP2(true) // Enable H2C (HTTP/2 cleartext)
+	protocols.SetHTTP1(false)           // Explicitly disable HTTP/1.1
+	protocols.SetHTTP2(false)           // Explicitly disable encrypted HTTP/2 (HTTPS)
+
+	// Note: You can modify the protocol support as needed:
+	// - protocols.SetHTTP1(true) to allow HTTP/1.1 connections
+	// - protocols.SetHTTP2(true) to allow encrypted HTTP/2 over TLS
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("Request: %s %s (HTTP/%d.%d)", r.Method, r.URL.Path, r.ProtoMajor, r.ProtoMinor)
+		fmt.Fprintf(w, "Hello from %s!\n", r.URL.Path)
+		fmt.Fprintf(w, "Protocol: HTTP/%d.%d\n", r.ProtoMajor, r.ProtoMinor)
+		fmt.Fprintf(w, "TLS: %v\n", r.TLS != nil)
+	})
+
+	server := &http.Server{
+		Addr:      ":8080",
+		Handler:   handler,
+		Protocols: protocols,
+	}
+
+	log.Println("Starting H2C server on :8080")
+	log.Println("Test with: curl -v --http2-prior-knowledge http://localhost:8080/test")
+	log.Fatal(server.ListenAndServe())
+}


### PR DESCRIPTION
Starting from Go 1.24, HTTP/2 Cleartext (H2C) is supported natively in the standard library, eliminating the need for golang.org/x/net/http2/h2c package or workarounds.

Since this repository ranks highly in search results for "golang h2c", "go http2 clear text", and similar queries, I've added examples demonstrating the modern approach to help developers discover the new native API.

Changes:
- Added cmd-1_24/ directory with working server and client examples using the native http.Protocols API
- Updated README to prominently feature Go 1.24+ native support at the top
- Preserved existing examples for users on Go < 1.24
- Included note about H2C upgrade deprecation
